### PR TITLE
@allenpaltrow Plants are now the unit of choice.

### DIFF
--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -1,0 +1,11 @@
+class Plant < ActiveRecord::Base
+  
+  attr_accessible :title, :body
+  
+  has_many :seeds, :class_name => "Plant", :foreign_key => "bucket_id"
+  belongs_to :bucket, :class_name => "Plant"
+  
+  belongs_to :user
+  belongs_to :vine
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,6 @@
+class User < ActiveRecord::Base
+  attr_accessible :name, :email
+  
+  has_many :plants
+  
+end

--- a/app/models/vine.rb
+++ b/app/models/vine.rb
@@ -1,0 +1,6 @@
+class Vine < ActiveRecord::Base
+  # attr_accessible :title, :body
+  
+  has_many :plants
+  
+end

--- a/db/migrate/20120622054313_create_schemea.rb
+++ b/db/migrate/20120622054313_create_schemea.rb
@@ -1,0 +1,28 @@
+class CreateSchemea < ActiveRecord::Migration
+  def change
+    create_table :seeds do |t|
+      t.string :title
+      t.text :body
+      t.integer :vine_id
+      t.integer :user_id
+      
+      t.timestamps
+    end
+    
+    create_table :vines do |t|
+      t.timestamps
+    end
+    
+    create_table :users do |t|
+      t.string :name
+      t.string :email
+      
+      t.timestamps
+    end
+    
+    drop_table :seed_buckets
+    
+    drop_table :containments
+  
+  end
+end

--- a/db/migrate/20120622055950_add_associations.rb
+++ b/db/migrate/20120622055950_add_associations.rb
@@ -1,0 +1,10 @@
+class AddAssociations < ActiveRecord::Migration
+  def change
+    create_table :plants do |t|
+      t.integer :bucket_id
+      t.integer :seed_id
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20120622132528_plants_seeds_users.rb
+++ b/db/migrate/20120622132528_plants_seeds_users.rb
@@ -1,0 +1,13 @@
+class PlantsSeedsUsers < ActiveRecord::Migration
+  def change
+    drop_table :plants
+    
+    create_table :plants do |t|
+      t.string :title
+      t.text :body
+      t.integer :bucket_id
+      
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20120622135720_add_users_vines.rb
+++ b/db/migrate/20120622135720_add_users_vines.rb
@@ -1,0 +1,8 @@
+class AddUsersVines < ActiveRecord::Migration
+  def change
+    change_table :plants do |t|
+      t.integer :user_id
+      t.integer :vine_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,20 +11,35 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120616140815) do
+ActiveRecord::Schema.define(:version => 20120622135720) do
 
-  create_table "containments", :force => true do |t|
+  create_table "plants", :force => true do |t|
+    t.string   "title"
+    t.text     "body"
     t.integer  "bucket_id"
-    t.integer  "seed_id"
-    t.integer  "order"
-    t.boolean  "in"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+    t.integer  "user_id"
+    t.integer  "vine_id"
+  end
+
+  create_table "seeds", :force => true do |t|
+    t.string   "title"
+    t.text     "body"
+    t.integer  "vine_id"
+    t.integer  "user_id"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end
 
-  create_table "seed_buckets", :force => true do |t|
-    t.string   "title"
-    t.text     "body"
+  create_table "users", :force => true do |t|
+    t.string   "name"
+    t.string   "email"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "vines", :force => true do |t|
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Plant do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/seed_spec.rb
+++ b/spec/models/seed_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Seed do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe User do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/vine_spec.rb
+++ b/spec/models/vine_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe Vine do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This is what I got:

Plants are now the basic model. A plant belongs_to a bucket and has_many seeds. However, buckets and seeds have :class_name "Plant." So really a plant belongs to a plant and has many plants at the same time. 

To try it out, clone my fork into another folder on your local machine and run "rake db:migrate." Open up your rails console and create two plants. Adding one of the plants to the other's "seeds" will make the one plant's bucket equal to the other plant and include the plant in the bucket plants seeds. 

There are also users and vines. Users have many plants, so that association is pretty easy. The same is true for vines. A vine is just another container that connects all iterations of a plant. 

I haven't touched the test suite....
